### PR TITLE
Fix two tests that were previously skipped

### DIFF
--- a/test/rootDSE.test.js
+++ b/test/rootDSE.test.js
@@ -22,11 +22,11 @@ tap.afterEach((done, t) => {
   done()
 })
 
-tap.skip('should return ECONNREFUSED for closed port', t => {
+tap.test('should return ECONNREFUSED for closed port', t => {
   ActiveDirectory.getRootDSE('ldap://127.0.0.1:389', (err) => {
     t.ok(err)
     t.type(err, Error)
-    t.equal(err.errno, 'ECONNREFUSED')
+    t.equal(err.code, 'ECONNREFUSED')
     t.end()
   })
 })

--- a/test/rootDSEPromised.test.js
+++ b/test/rootDSEPromised.test.js
@@ -22,13 +22,13 @@ tap.afterEach((done, t) => {
   done()
 })
 
-tap.skip('should return ECONNREFUSED for closed port', t => {
+tap.test('should return ECONNREFUSED for closed port', t => {
   return ActiveDirectory.getRootDSE('ldap://127.0.0.1:389')
     .then(() => t.fail('should not be invoked'))
     .catch((err) => {
       t.ok(err)
       t.type(err, Error)
-      t.equal(err.errno, 'ECONNREFUSED')
+      t.equal(err.code, 'ECONNREFUSED')
     })
 })
 


### PR DESCRIPTION
These tests were passing on Node 12. 

On Node 14, `SystemError.errno` becomes a numeric value. 

In contrast, `Error.code` contains the code we expect, and this works on Node 12 and 14.