### PR TITLE
Add the supportNestedGroup option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ wallaby.js
 
 .project
 .idea
+.vscode
 
 samples
 node_modules

--- a/lib/components/getGroupMembershipForDN.js
+++ b/lib/components/getGroupMembershipForDN.js
@@ -20,7 +20,7 @@ let search
  * @constructor
  */
 function GroupMembersForDN (opts, dn, callback, stack) {
-  this.opts = opts
+  this.opts = Object.assign({ supportNestedGroups: true }, opts)
   this.dn = dn
   this.callback = callback
   this.stack = stack || new Map()
@@ -37,26 +37,30 @@ GroupMembersForDN.prototype.asyncIterator = function asyncIterator (group, acb) 
     return acb()
   }
 
-  if (utils.isGroupResult(group)) {
-    log.trace('Adding group "%s" to %s"', group.dn, this.dn)
-    const g = new Group(group)
-    this.stack.set(g.cn || g.dn, g)
-
-    const getter = new GroupMembersForDN(this.opts, g.dn, (err, nestedGroups) => {
-      if (err) {
-        return acb(err)
-      }
-      nestedGroups.forEach((ng) => {
-        if (!this.stack.has(ng.cn || ng.dn)) {
-          this.stack.set(ng.cn || ng.dn, ng)
-        }
-      })
-      acb()
-    }, this.stack)
-    getter.getMembers()
-  } else {
-    acb()
+  if (!utils.isGroupResult(group)) {
+    return acb()
   }
+
+  log.trace('Adding group "%s" to %s"', group.dn, this.dn)
+  const g = new Group(group)
+  this.stack.set(g.cn || g.dn, g)
+
+  if (!this.opts.supportNestedGroups) {
+    return acb()
+  }
+
+  const getter = new GroupMembersForDN(this.opts, g.dn, (err, nestedGroups) => {
+    if (err) {
+      return acb(err)
+    }
+    nestedGroups.forEach((ng) => {
+      if (!this.stack.has(ng.cn || ng.dn)) {
+        this.stack.set(ng.cn || ng.dn, ng)
+      }
+    })
+    acb()
+  }, this.stack)
+  getter.getMembers()
 }
 
 /**

--- a/lib/components/search.js
+++ b/lib/components/search.js
@@ -305,6 +305,8 @@ Searcher.prototype.removeReferral = function removeReferral (referral) {
  * Default: base.
  * @property {string} [filter] The LDAP filter to use.
  * Default: '(objectclass=*)'
+ * @property {boolean} [supportNestedGroups] Whether to resolve nested
+ * hieararchy in parent groups. Default: true.
  * @property {array} [attributes] A list of entry attributes to include in the
  * result. Defaults to all attributes.
  * @property {int} [sizeLimit] The maximum number of entries to return.

--- a/test/getgroupmembershipfordn.test.js
+++ b/test/getgroupmembershipfordn.test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const tap = require('tap')
+const ActiveDirectory = require('../index')
+const config = require('./config')
+const serverFactory = require('./mockServer')
+const settings = require('./settings').getGroupMembershipForDN
+
+tap.beforeEach((done, t) => {
+  serverFactory(function (err, server) {
+    if (err) return done(err)
+    const connectionConfig = config(server.port)
+    t.context.ad = new ActiveDirectory(connectionConfig)
+    t.context.server = server
+    done()
+  })
+})
+
+tap.afterEach((done, t) => {
+  if (t.context.server) t.context.server.close()
+  done()
+})
+
+tap.test('#getGroupMembershipForDN()', t => {
+  settings.groups.forEach((group) => {
+    t.test(`should return groups (with nested groups) for ${group.dn}`, t => {
+      const opts = { supportNestedGroups: true }
+      const expectedGroups = [...group.groups, ...group.nestedGroups]
+      t.context.ad.getGroupMembershipForDN(opts, group.dn, undefined, function (err, groups) {
+        t.error(err)
+        t.ok(groups)
+        t.type(groups, Array)
+
+        const cns = groups.map((g) => g.cn)
+        expectedGroups.forEach(group => t.true(cns.includes(group)))
+
+        t.end()
+      })
+    })
+
+    t.test(`should return groups (without nested groups) for ${group.dn}`, t => {
+      const opts = { supportNestedGroups: false }
+      const expectedGroups = group.groups
+      t.context.ad.getGroupMembershipForDN(opts, group.dn, undefined, function (err, groups) {
+        t.error(err)
+        t.ok(groups)
+        t.type(groups, Array)
+
+        const cns = groups.map((g) => g.cn)
+        expectedGroups.forEach(group => t.true(cns.includes(group)))
+
+        t.end()
+      })
+    })
+  })
+
+  t.end()
+})

--- a/test/getgroupmembershipfordn.test.js
+++ b/test/getgroupmembershipfordn.test.js
@@ -25,14 +25,14 @@ tap.test('#getGroupMembershipForDN()', t => {
   settings.groups.forEach((group) => {
     t.test(`should return groups (with nested groups) for ${group.dn}`, t => {
       const opts = { supportNestedGroups: true }
-      const expectedGroups = [...group.groups, ...group.nestedGroups]
+      const expectedGroups = [...group.groups, ...group.nestedGroups].sort()
       t.context.ad.getGroupMembershipForDN(opts, group.dn, undefined, function (err, groups) {
         t.error(err)
         t.ok(groups)
         t.type(groups, Array)
 
-        const cns = groups.map((g) => g.cn)
-        expectedGroups.forEach(group => t.true(cns.includes(group)))
+        const actualGroups = groups.map((g) => g.cn).sort()
+        t.strictSame(actualGroups, expectedGroups)
 
         t.end()
       })
@@ -40,14 +40,14 @@ tap.test('#getGroupMembershipForDN()', t => {
 
     t.test(`should return groups (without nested groups) for ${group.dn}`, t => {
       const opts = { supportNestedGroups: false }
-      const expectedGroups = group.groups
+      const expectedGroups = group.groups.sort()
       t.context.ad.getGroupMembershipForDN(opts, group.dn, undefined, function (err, groups) {
         t.error(err)
         t.ok(groups)
         t.type(groups, Array)
 
-        const cns = groups.map((g) => g.cn)
-        expectedGroups.forEach(group => t.true(cns.includes(group)))
+        const actualGroups = groups.map((g) => g.cn).sort()
+        t.strictSame(actualGroups, expectedGroups)
 
         t.end()
       })

--- a/test/mockServer/schema.js
+++ b/test/mockServer/schema.js
@@ -31,6 +31,7 @@ schema.com.domain['domain groups'] = {
   'Account - Department #3', 'Account - Department #4',
   'All Directors', 'Another Group', 'Authors', 'Budget Users', 'Domain Admins',
   'My Group', 'My Group #1', 'My Group #2', 'My Nested Users', 'My Users',
+  'My Nested Nested Users', 'My Nested Nested Nested Users',
   'Parking Department', 'Parking Users', 'Security Users', 'Security Owners',
   'System Directors',
   'VPN Users',
@@ -88,6 +89,14 @@ schema.com.domain['domain groups']['vpn users']
 schema.com.domain['domain groups']['web users']
   .value.attributes.memberOf.push(
     schema.com.domain['domain groups']['my users'].value
+  )
+schema.com.domain['domain groups']['my nested nested users']
+  .value.attributes.memberOf.push(
+    schema.com.domain['domain groups']['my nested users'].value
+  )
+schema.com.domain['domain groups']['my nested nested nested users']
+  .value.attributes.memberOf.push(
+    schema.com.domain['domain groups']['my nested nested users'].value
   )
 
 schema.com.domain['domain groups']['another group']

--- a/test/settings.js
+++ b/test/settings.js
@@ -36,6 +36,24 @@ module.exports = {
       dn: 'CN=First Last Name,OU=Domain Users,DC=domain,DC=com'
     }
   },
+  // Test settings for getGroupMembershipForDN
+  getGroupMembershipForDN: {
+    groups: [{
+      dn: 'CN=My Users,OU=Domain Groups,DC=domain,DC=com',
+      groups: [
+        'My Nested Users', 'VPN Users', 'Web Users'
+      ],
+      nestedGroups: [
+        'My Nested Nested Users', 'My Nested Nested Nested Users'
+      ]
+    }, {
+      dn: 'CN=Authors,OU=Domain Groups,DC=domain,DC=com',
+      groups: [
+        'Editors', 'Contributors', 'Web Editors', 'Web Users'
+      ],
+      nestedGroups: []
+    }]
+  },
   // Test settings for getGroupMembershipForGroup
   getGroupMembershipForGroup: {
     groups: [{


### PR DESCRIPTION
This ports https://github.com/Linkurious/node-activedirectory/pull/1

Note I've added unit tests for the `getGroupMembershipForDN()` function (there were none).